### PR TITLE
feat(upload): implement image upload functionality with validation and response

### DIFF
--- a/app/Http/Controllers/Api/V1/UploadController.php
+++ b/app/Http/Controllers/Api/V1/UploadController.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Exceptions\BadRequestException;
+use App\Http\Controllers\BaseController;
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+use Illuminate\Support\Str;
+
+class UploadController extends BaseController
+{
+    //
+
+    /**
+     * @throws BadRequestException
+     */
+    public function uploadImage(Request $request)
+    {
+        $request->validate([
+            'image' => 'required|image|mimes:jpeg,png,jpg,gif,svg|max:2048',
+        ]);
+
+        if ($request->file('image')->isValid()) {
+            $fileName = Str::uuid() . '.' . $request->file('image')->getClientOriginalExtension();
+
+            $filePath = $request->file('image')->storeAs('uploads/images', $fileName, 'public');
+            $fileUrl = asset('storage/' . $filePath);
+            return $this->apiSuccessSingleResponse(
+                JsonResource::make([
+                    'file_name' => $fileName,
+                    'file_path' => 'storage/' . $filePath,
+                    'file_url' => $fileUrl,
+                ])
+            );
+        }
+
+        throw new BadRequestException(
+            'Invalid image file provided.',
+            400
+        );
+    }
+}


### PR DESCRIPTION
This pull request introduces a new `UploadController` to handle image uploads in the API. The controller includes validation, file storage, and response formatting for uploaded images.

### New Feature: Image Upload Handling

* Added `UploadController` in `app/Http/Controllers/Api/V1/UploadController.php` to manage image uploads. The `uploadImage` method validates the uploaded file, stores it in the `uploads/images` directory, and returns a JSON response with the file name, path, and URL. The method also throws a `BadRequestException` if the file is invalid