### PR TITLE
refactor(auth): rename 'me' method to 'getMyProfile' for clarity in API routes

### DIFF
--- a/app/Http/Controllers/Api/V1/AuthController.php
+++ b/app/Http/Controllers/Api/V1/AuthController.php
@@ -48,7 +48,7 @@ class AuthController extends BaseController
         );
     }
 
-    function me(Request $request): JsonResponse
+    function getMyProfile(Request $request): JsonResponse
     {
         $user = $request->user();
         return $this->apiSuccessSingleResponse(

--- a/routes/api.php
+++ b/routes/api.php
@@ -18,7 +18,7 @@ Route::prefix("v1")->group(function () {
         Route::post('/forgot-password', [AuthController::class, 'forgotPassword']);
         Route::post('/reset-password', [AuthController::class, 'resetPassword']);
         Route::middleware('auth:api')->post('/logout', [AuthController::class, 'logout']);
-        Route::middleware('auth:api')->get('/me', [AuthController::class, 'me']);
+        Route::middleware('auth:api')->get('/me', [AuthController::class, 'getMyProfile']);
     });
 
 


### PR DESCRIPTION
This pull request includes a minor but important change to improve the clarity and consistency of method naming in the `AuthController` and its corresponding route definition.

### Changes to method naming:

* [`app/Http/Controllers/Api/V1/AuthController.php`](diffhunk://#diff-1980189cc613e46793f79719b7a0157afd7296eb613e72aa305566e5224b0487L51-R51): Renamed the `me` method to `getMyProfile` to better reflect its purpose of retrieving the authenticated user's profile.
* [`routes/api.php`](diffhunk://#diff-0e4323e6a03c91c9c8dc88afef15fdad09636468c0ac3550f497618372788b6dL21-R21): Updated the route definition to use `getMyProfile` instead of `me` for the `/me` endpoint, ensuring consistency with the renamed method in `AuthController`.

## Summary by Sourcery

Rename the `me` endpoint method to `getMyProfile` in AuthController and update the corresponding API route to reflect the new method name for improved clarity and consistency.

Enhancements:
- Rename AuthController method `me` to `getMyProfile`
- Update `/me` API route to reference the renamed `getMyProfile` method